### PR TITLE
Fixed all swipers and moved LandingHeader to Layout

### DIFF
--- a/src/components/BrandSlider.astro
+++ b/src/components/BrandSlider.astro
@@ -7,6 +7,7 @@ export interface Props {
 
 }
 
+// const swiperId = (new Date().valueOf()).toString();
 const { imageCar, brand } = Astro.props as Props;
 ---
 
@@ -41,7 +42,7 @@ const { imageCar, brand } = Astro.props as Props;
 </style>
 
 
-<div class="swiper mySwiper">
+<div class="swiper" id="swiper-BrandSlider">
   <div class="swiper-wrapper">
     <div class="swiper-slide"><img alt=`${brand} 0` src=`${imageCar[0]}`></div>
     <div class="swiper-slide"><img alt=`${brand} 1` src=`${imageCar[1]}`></div>
@@ -50,14 +51,11 @@ const { imageCar, brand } = Astro.props as Props;
 </div>
 
 <script>
-// import Swiper JS
-import Swiper from 'swiper';
-// import Swiper styles
-import 'swiper/css';
+  import Swiper from 'swiper';
+  import 'swiper/css';
 
-const swiper = new Swiper(".mySwiper", {
+  new Swiper('#swiper-BrandSlider', {
       effect: "cards",
       grabCursor: true,
     });
-
 </script>

--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -1,67 +1,70 @@
+---
+// const swiperId = "Carousel-" + (new Date().valueOf()).toString();
+---
+
 <style>
     .swiper {
-      width: 100%;
-      height: 100vh;
+        width: 100%;
+        height: 100vh;
     }
 
     .swiper-slide {
-      text-align: center;
-      font-size: 18px;
-      background: #fff;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+        text-align: center;
+        font-size: 18px;
+        background: #fff;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .swiper-slide img {
-      display: block;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
     }
 
     .swiper {
-      margin-left: auto;
-      margin-right: auto;
+        margin-left: auto;
+        margin-right: auto;
     }
 </style>
 
 
-<div class="swiper mySwiper">
-  <div class="swiper-wrapper">
-    <div class="swiper-slide"><img alt="tesla model-s" src="/model-s.webp"></div>
-    <div class="swiper-slide"><img alt="mclaren 720s" src="/mclaren-blanco.jpg"></div>
-    <div class="swiper-slide"><img alt="chevrolet camaro" src="/chevrolet-camaro.jpg"></div>
-    <div class="swiper-slide"><img alt="Lamborghini Huracan" src="/lamborghini-huracan.jpg"></div>
-  </div>
-  <div class="swiper-button-next"></div>
-  <div class="swiper-button-prev"></div>
-  <div class="swiper-pagination"></div>
-
+<div class="swiper" id="swiper-Carousel">
+    <div class="swiper-wrapper">
+        <div class="swiper-slide"><img alt="tesla model-s" src="/model-s.webp"></div>
+        <div class="swiper-slide"><img alt="mclaren 720s" src="/mclaren-blanco.jpg"></div>
+        <div class="swiper-slide"><img alt="chevrolet camaro" src="/chevrolet-camaro.jpg"></div>
+        <div class="swiper-slide"><img alt="Lamborghini Huracan" src="/lamborghini-huracan.jpg"></div>
+    </div>
+    <div class="swiper-button-next"></div>
+    <div class="swiper-button-prev"></div>
+    <div class="swiper-pagination"></div>
 </div>
 
 <script>
-// import Swiper JS
-import Swiper from 'swiper';
-// import Swiper styles
-import 'swiper/css';
+    import Swiper from 'swiper';
+    import {Navigation, Pagination, Autoplay} from 'swiper/modules';
+    import 'swiper/css';
+    import 'swiper/css/navigation';
+    import 'swiper/css/pagination';
 
-const swiper = new Swiper('.mySwiper', {
-  slidesPerView: 1,
-  spaceBetween: 30,
-  loop: true,
-  pagination: {
-    el: '.swiper-pagination',
-    clickable: true,
-  },
-  autoplay: {
-    delay: 2500,
-    disableOnInteraction: false,
-  },
-  navigation: {
-    nextEl: '.swiper-button-next',
-    prevEl: '.swiper-button-prev',
-  },
-});
-
+    new Swiper(`#swiper-Carousel`, {
+        modules: [Navigation, Pagination, Autoplay],
+        slidesPerView: 1,
+        loop: true,
+        pagination: {
+            el: `#swiper-Carousel > .swiper-pagination`,
+            clickable: true,
+        },
+        autoplay: {
+            delay: 5000,
+            disableOnInteraction: false,
+        },
+        navigation: {
+            nextEl: `#swiper-Carousel > .swiper-button-next`,
+            prevEl: `#swiper-Carousel > .swiper-button-prev`,
+        },
+    });
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,11 @@
 ---
+import LandingHeader from "../components/LandingHeader.astro";
 export interface Props {
   title: string
+  landingHeader: boolean // Whether to render the landing header. Is true by default
 }
 
-const { title } = Astro.props
+const { title, landingHeader=true } = Astro.props
 ---
 
 <!DOCTYPE html>
@@ -12,16 +14,11 @@ const { title } = Astro.props
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"
-    />
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
   </head>
   <body>
+    {landingHeader && <LandingHeader />}
     <slot />
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import HeroSection from "../components/HeroSection.astro";
-import LandingHeader from "../components/LandingHeader.astro";
 import Footer from "../components/Footer.astro";
 import Layout from "../layouts/Layout.astro";
 import Descripcion from "../components/Descripcion.astro";
@@ -9,8 +8,6 @@ import BrandCollection from "../components/BrandCollection.astro";
 ---
 
 <Layout title="San Andreas Motorsports">
-  <LandingHeader />
-
   <main
     class="snap-y snap-mandatory relative w-full h-screen overflow-y-auto overflow-x-hidden scroll-smooth"
   >
@@ -21,10 +18,10 @@ import BrandCollection from "../components/BrandCollection.astro";
       <Descripcion />
     </div>
     <div class="snap-center">
-      <Carousel/>
+      <Carousel />
     </div>
     <div class="snap-end">
-      <BrandCollection/>
+      <BrandCollection />
     </div>
   </main>
 </Layout>

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -1,5 +1,4 @@
 ---
-import LandingHeader from "../components/LandingHeader.astro";
 import Layout from "../layouts/Layout.astro";
 import SectionColor from "../components/SectionColor.astro";
 import SectionRuedas from "../components/SectionRuedas.astro"
@@ -8,8 +7,6 @@ import SectionConfirm from "../components/SectionConfirm.astro"
 ---
 
 <Layout title="San Andreas Motorsports">
-  <LandingHeader />
-
   <main
     class="snap-y snap-mandatory relative w-full h-screen overflow-y-auto overflow-x-hidden scroll-smooth"
   >


### PR DESCRIPTION
Before, the `Swiper` components, namely `Carousel` and `BrandSlider` were not working as expected (weird displacement in the slides and buttons/pagination not functioning), and relied on importing `Swiper` through a CDN (not good). The issue was twofold. First, the two declarations of the `Swiper`s were in conflict, because they depended on the same CSS selection. Secondly, we needed to import the modules `Navigation`, `Pagination`, and `Autoplay` if we didn't want to use the CDN for fetching the library. This branch fixes those two issues. 

Moreover, this branch reformats `Layout` and our two pages so that the `LandingHeader` is moved to layout. `Layout` still retains the option to not include the `LandingHeader` through the `landingHeader` boolean parameter (`true` by default).
